### PR TITLE
Change Hypixel Mod API from embedded to required dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ configurations { shade }
 // Configures the libraries/dependencies for your mod.
 dependencies {
     shade("com.squareup.okhttp3:okhttp:4.9.3") { exclude(group = "org.jetbrains.kotlin") }
-    shade("net.hypixel:mod-api:1.0")
+    modImplementation("net.hypixel:mod-api:1.0")
     shade("org.tukaani:xz:1.9")
     testImplementation("junit:junit:4.13.2")
     // Adds the OneConfig library, so we can develop with it.

--- a/src/main/java/com/roxiun/mellow/Mellow.java
+++ b/src/main/java/com/roxiun/mellow/Mellow.java
@@ -55,7 +55,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import org.lwjgl.input.Keyboard;
 
-@Mod(modid = Mellow.MODID, name = Mellow.NAME, version = Mellow.VERSION)
+@Mod(modid = Mellow.MODID, name = Mellow.NAME, version = Mellow.VERSION, dependencies = "required-after:hypixel_mod_api")
 public class Mellow {
 
     public static final String MODID = "mellow";

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -11,6 +11,6 @@
     "credits": "melissalmao and xanning for og mod",
     "logoFile": "",
     "screenshots": [],
-    "dependencies": []
+    "dependencies": ["hypixel_mod_api"]
   }
 ]


### PR DESCRIPTION
Shading mod dependencies is a bad practice that used to be common in the modding community. When two mods shade the same dependency, it gets loaded twice, which can cause several issues. Currently, the game crashes on startup when both Mellow and Hypixel Mod API are present in the same modpack